### PR TITLE
Compiler warning fixes

### DIFF
--- a/DFM/dfmCrashCatcher.c
+++ b/DFM/dfmCrashCatcher.c
@@ -19,7 +19,7 @@
 
 #if ((DFM_CFG_CRASH_ADD_TRACE) >= 1)
 #include <trcRecorder.h>
-static void prvAddTracePayload();
+static void prvAddTracePayload(void);
 #endif
 
 /* See https://developer.arm.com/documentation/dui0552/a/cortex-m3-peripherals/system-control-block/configurable-fault-status-register*/
@@ -173,7 +173,7 @@ void CrashCatcher_DumpStart(const CrashCatcherInfo* pInfo)
 }
 
 #if ((DFM_CFG_CRASH_ADD_TRACE) >= 1)
-static void prvAddTracePayload()
+static void prvAddTracePayload(void)
 {
 	char* szName;
 	void* pvBuffer = (void*)0;

--- a/DFM/dfmCrashCatcher.c
+++ b/DFM/dfmCrashCatcher.c
@@ -55,7 +55,7 @@ static char* prvGetFileNameFromPath(char* szPath)
 static uint32_t prvCalculateChecksum(char *ptr, size_t maxlen)
 {
 	uint32_t chksum = 0;
-	int i = 0;
+	size_t i = 0;
 
 	if (ptr == NULL)
 	{

--- a/DFM/dfmSession.c
+++ b/DFM/dfmSession.c
@@ -135,10 +135,11 @@ DfmResult_t xDfmSessionEnable(uint32_t ulOverride)
 	if ((ulStoredEnabledValue == DFM_SESSION_STORAGE_DUMMY_VALUE) || ((ulOverride == 1UL) && (ulStoredEnabledValue == DFM_DISABLED)))
 	{
 		/* Couldn't read stored value or we override a disabled value */
-		((DfmSessionStorage_t*)cSessionStorageBuffer)->ulVersion = DFM_SESSION_STORAGE_VERSION; /*cstat !MISRAC2012-Rule-11.3 We use an untyped buffer to retrieve the session data since we can't know what version and size it might have been stored in the past. The stored Session data might be larger than the current DfmSessionStorage_t*/
-		((DfmSessionStorage_t*)cSessionStorageBuffer)->ulEnabled = DFM_ENABLED; /*cstat !MISRAC2012-Rule-11.3 We use an untyped buffer to retrieve the session data since we can't know what version and size it might have been stored in the past. The stored Session data might be larger than the current DfmSessionStorage_t*/
+		DfmSessionStorage_t *pxSessionStorage = (DfmSessionStorage_t*)&cSessionStorageBuffer[0];
+		pxSessionStorage->ulVersion = DFM_SESSION_STORAGE_VERSION; /*cstat !MISRAC2012-Rule-11.3 We use an untyped buffer to retrieve the session data since we can't know what version and size it might have been stored in the past. The stored Session data might be larger than the current DfmSessionStorage_t*/
+		pxSessionStorage->ulEnabled = DFM_ENABLED; /*cstat !MISRAC2012-Rule-11.3 We use an untyped buffer to retrieve the session data since we can't know what version and size it might have been stored in the past. The stored Session data might be larger than the current DfmSessionStorage_t*/
 
-		(void)xDfmStorageStoreSession(cSessionStorageBuffer, sizeof(DfmSessionStorage_t)); /* Attempt to store the session info. We can't really do anything if it fails. */
+		(void)xDfmStorageStoreSession(pxSessionStorage, sizeof(DfmSessionStorage_t)); /* Attempt to store the session info. We can't really do anything if it fails. */
 
 		ulStoredEnabledValue = DFM_ENABLED;
 	}
@@ -182,12 +183,13 @@ DfmResult_t xDfmSessionDisable(uint32_t ulRemember)
 	if (ulStoredEnabledValue != DFM_DISABLED)
 	{
 		/* We didn't find disabled */
-		((DfmSessionStorage_t*)cSessionStorageBuffer)->ulVersion = DFM_SESSION_STORAGE_VERSION; /*cstat !MISRAC2012-Rule-11.3 We use an untyped buffer to retrieve the session data since we can't know what version and size it might have been stored in the past. The stored Session data might be larger than the current DfmSessionStorage_t*/
-		((DfmSessionStorage_t*)cSessionStorageBuffer)->ulEnabled = DFM_DISABLED; /*cstat !MISRAC2012-Rule-11.3 We use an untyped buffer to retrieve the session data since we can't know what version and size it might have been stored in the past. The stored Session data might be larger than the current DfmSessionStorage_t*/
+		DfmSessionStorage_t *pxSessionStorage = (DfmSessionStorage_t*)&cSessionStorageBuffer[0];
+		pxSessionStorage->ulVersion = DFM_SESSION_STORAGE_VERSION; /*cstat !MISRAC2012-Rule-11.3 We use an untyped buffer to retrieve the session data since we can't know what version and size it might have been stored in the past. The stored Session data might be larger than the current DfmSessionStorage_t*/
+		pxSessionStorage->ulEnabled = DFM_DISABLED; /*cstat !MISRAC2012-Rule-11.3 We use an untyped buffer to retrieve the session data since we can't know what version and size it might have been stored in the past. The stored Session data might be larger than the current DfmSessionStorage_t*/
 
 		if (ulRemember != 0UL)
 		{
-			(void)xDfmStorageStoreSession(cSessionStorageBuffer, sizeof(DfmSessionStorage_t)); /* Attempt to store the session info. We can't really do anything if it fails. */
+			(void)xDfmStorageStoreSession(pxSessionStorage, sizeof(DfmSessionStorage_t)); /* Attempt to store the session info. We can't really do anything if it fails. */
 		}
 	}
 


### PR DESCRIPTION
Fixes needed when enabling `strict-prototypes` and `strict-aliasing` compiler warnings