### PR TITLE
Fix SyntaxWarning: invalid escape sequence '\s' warnings

### DIFF
--- a/TraceRecorder/kernelports/Zephyr/scripts/tz_parse_syscalls.py
+++ b/TraceRecorder/kernelports/Zephyr/scripts/tz_parse_syscalls.py
@@ -48,11 +48,11 @@ with open("{}/VERSION".format(args.zephyr_base), "r") as fh:
     minor = None
     patch_level = None
     for line in fh:
-        if matches := re.match('^VERSION_MAJOR\s*=\s*(\d+)$', line):
+        if matches := re.match(r'^VERSION_MAJOR\s*=\s*(\d+)$', line):
             major = int(matches.group(1))
-        elif matches := re.match('^VERSION_MINOR\s*=\s*(\d+)$', line):
+        elif matches := re.match(r'^VERSION_MINOR\s*=\s*(\d+)$', line):
             minor = int(matches.group(1))
-        elif matches := re.match('^PATCHLEVEL\s*=\s*(\d+)$', line):
+        elif matches := re.match(r'^PATCHLEVEL\s*=\s*(\d+)$', line):
             patch_level = int(matches.group(1))
 
     if major is None or minor is None or patch_level is None:
@@ -65,7 +65,7 @@ syscalls = []
 syscall_exit_start_id = None
 with open(syscall_list_h, 'r') as fh:
     for line in fh:
-        matches = re.match('^#define\sK_SYSCALL_((\w|_)+)\s(\d+)$', line)
+        matches = re.match(r'^#define\s+K_SYSCALL_((\w|_)+)\s(\d+)$', line)
         if matches:
             syscall_name = matches.group(1)
             syscall_id = matches.group(3)


### PR DESCRIPTION
When building the following is printed

```
/home/pdgendt/zephyrproject/modules/debug/percepio/TraceRecorder/kernelports/Zephyr/scripts/tz_parse_syscalls.py:51: SyntaxWarning: invalid escape sequence '\s'
  if matches := re.match('^VERSION_MAJOR\s*=\s*(\d+)$', line):
/home/pdgendt/zephyrproject/modules/debug/percepio/TraceRecorder/kernelports/Zephyr/scripts/tz_parse_syscalls.py:53: SyntaxWarning: invalid escape sequence '\s'
  elif matches := re.match('^VERSION_MINOR\s*=\s*(\d+)$', line):
/home/pdgendt/zephyrproject/modules/debug/percepio/TraceRecorder/kernelports/Zephyr/scripts/tz_parse_syscalls.py:55: SyntaxWarning: invalid escape sequence '\s'
  elif matches := re.match('^PATCHLEVEL\s*=\s*(\d+)$', line):
/home/pdgendt/zephyrproject/modules/debug/percepio/TraceRecorder/kernelports/Zephyr/scripts/tz_parse_syscalls.py:68: SyntaxWarning: invalid escape sequence '\s'
  matches = re.match('^#define\sK_SYSCALL_((\w|_)+)\s(\d+)$', line)
```