### PR TITLE
zephyr: fix condvar_wait enter/exit arguments

### DIFF
--- a/TraceRecorder/kernelports/Zephyr/include/tracing_tracerecorder.h
+++ b/TraceRecorder/kernelports/Zephyr/include/tracing_tracerecorder.h
@@ -387,10 +387,10 @@ extern "C" {
     sys_trace_k_condvar_broadcast_exit(condvar, ret)
 #undef sys_port_trace_k_condvar_wait_enter
 #define sys_port_trace_k_condvar_wait_enter(condvar, ...)                           \
-    sys_trace_k_condvar_wait_enter(condvar, mutex, timeout)
+    sys_trace_k_condvar_wait_enter(condvar, timeout)
 #undef sys_port_trace_k_condvar_wait_exit
-#define sys_port_trace_k_condvar_wait_exit(condvar, ret, ...)                       \
-    sys_trace_k_condvar_wait_exit(condvar, mutex, timeout, ret)
+#define sys_port_trace_k_condvar_wait_exit(condvar, ...)                            \
+    sys_trace_k_condvar_wait_exit(condvar, timeout, ret)
 
 
 /* Queue trace mappings */
@@ -1043,10 +1043,8 @@ void sys_trace_k_condvar_signal_blocking(struct k_condvar *condvar);
 void sys_trace_k_condvar_signal_exit(struct k_condvar *condvar, int ret);
 void sys_trace_k_condvar_broadcast_enter(struct k_condvar *condvar);
 void sys_trace_k_condvar_broadcast_exit(struct k_condvar *condvar, int ret);
-void sys_trace_k_condvar_wait_enter(struct k_condvar *condvar,
-    struct k_mutex *mutex, k_timeout_t timeout);
-void sys_trace_k_condvar_wait_exit(struct k_condvar *condvar,
-    struct k_mutex *mutex, k_timeout_t timeout, int ret);
+void sys_trace_k_condvar_wait_enter(struct k_condvar *condvar, k_timeout_t timeout);
+void sys_trace_k_condvar_wait_exit(struct k_condvar *condvar, k_timeout_t timeout, int ret);
 
 
 /* Queue trace function declarations */

--- a/TraceRecorder/kernelports/Zephyr/include/trcKernelPort.h
+++ b/TraceRecorder/kernelports/Zephyr/include/trcKernelPort.h
@@ -43,7 +43,7 @@ extern "C" {
  * @def TRC_PLATFORM_CFG_MINOR
  * @brief Minor release version for recorder.
  */
-#define TRC_PLATFORM_CFG_MINOR 1
+#define TRC_PLATFORM_CFG_MINOR 3
 
 /**
  * @def TRC_PLATFORM_CFG_PATCH

--- a/TraceRecorder/kernelports/Zephyr/trcKernelPort.c
+++ b/TraceRecorder/kernelports/Zephyr/trcKernelPort.c
@@ -785,12 +785,12 @@ void sys_trace_k_condvar_broadcast_exit(struct k_condvar *condvar, int ret) {
 	(void)xTraceEventCreate2(PSF_EVENT_CONDVAR_BROADCAST_EXIT, (TraceUnsignedBaseType_t)condvar, (TraceUnsignedBaseType_t)ret);
 }
 
-void sys_trace_k_condvar_wait_enter(struct k_condvar *condvar, struct k_mutex *mutex, k_timeout_t timeout) {
-	(void)xTraceEventCreate3(PSF_EVENT_CONDVAR_WAIT_BLOCKING, (TraceUnsignedBaseType_t)condvar, (TraceUnsignedBaseType_t)mutex, (TraceUnsignedBaseType_t)timeout.ticks);
+void sys_trace_k_condvar_wait_enter(struct k_condvar *condvar, k_timeout_t timeout) {
+	(void)xTraceEventCreate2(PSF_EVENT_CONDVAR_WAIT_BLOCKING, (TraceUnsignedBaseType_t)condvar, (TraceUnsignedBaseType_t)timeout.ticks);
 }
 
-void sys_trace_k_condvar_wait_exit(struct k_condvar *condvar, struct k_mutex *mutex, k_timeout_t timeout, int ret) {
-	(void)xTraceEventCreate3(ret == 0 ? PSF_EVENT_CONDVAR_WAIT_SUCCESS : PSF_EVENT_CONDVAR_WAIT_FAILURE, (TraceUnsignedBaseType_t)condvar, (TraceUnsignedBaseType_t)mutex, (TraceUnsignedBaseType_t)ret);
+void sys_trace_k_condvar_wait_exit(struct k_condvar *condvar, k_timeout_t timeout, int ret) {
+	(void)xTraceEventCreate2(ret == 0 ? PSF_EVENT_CONDVAR_WAIT_SUCCESS : PSF_EVENT_CONDVAR_WAIT_FAILURE, (TraceUnsignedBaseType_t)condvar, (TraceUnsignedBaseType_t)ret);
 }
 
 


### PR DESCRIPTION
Remove mutex from arguments.